### PR TITLE
Remove Expo warning package needs 'requires main queue setup'

### DIFF
--- a/ios/BarcodeCreatorViewManager.swift
+++ b/ios/BarcodeCreatorViewManager.swift
@@ -14,6 +14,9 @@ class BarcodeCreatorViewManager: RCTViewManager {
                 "UPCA": "CIEANBarcodeGenerator"
         ]
     }
+    @objc override static func requiresMainQueueSetup() -> Bool {
+      return true
+    }
 }
 
 class BarcodeCreatorView :  UIView {

--- a/ios/BarcodeCreatorViewManager.swift
+++ b/ios/BarcodeCreatorViewManager.swift
@@ -14,7 +14,7 @@ class BarcodeCreatorViewManager: RCTViewManager {
                 "UPCA": "CIEANBarcodeGenerator"
         ]
     }
-    @objc override static func requiresMainQueueSetup() -> Bool {
+    @objc override func requiresMainQueueSetup() -> Bool {
       return true
     }
 }


### PR DESCRIPTION
Per react native doc, modules needs 

```
@objc override func requiresMainQueueSetup() -> Bool {
    return true
}
```

as it returns

```
   override func constantsToExport()
```

Reference:
https://reactnative.dev/docs/native-modules-ios