### PR TITLE
Make requiresMainQueueSetup static

### DIFF
--- a/ios/BarcodeCreatorViewManager.swift
+++ b/ios/BarcodeCreatorViewManager.swift
@@ -14,7 +14,7 @@ class BarcodeCreatorViewManager: RCTViewManager {
                 "UPCA": "CIEANBarcodeGenerator"
         ]
     }
-    @objc override func requiresMainQueueSetup() -> Bool {
+    @objc override static func requiresMainQueueSetup() -> Bool {
       return true
     }
 }


### PR DESCRIPTION
Fixes build problem.
Add `static` qualifier to override of requiresMainQueueSetup.