### PR TITLE
✅ Updated Android build.gradle with new compileSdkVersion and targetSdkVersion (34) to support new projects

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('BarcodeCreator_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('BarcodeCreator_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('BarcodeCreator_compileSdkVersion', 30)
+    buildToolsVersion safeExtGet('BarcodeCreator_buildToolsVersion', '30.0.3')
     defaultConfig {
-        minSdkVersion safeExtGet('BarcodeCreator_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('BarcodeCreator_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('BarcodeCreator_minSdkVersion', 23)
+        targetSdkVersion safeExtGet('BarcodeCreator_targetSdkVersion', 30)
         versionCode 1
         versionName "1.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('BarcodeCreator_compileSdkVersion', 30)
-    buildToolsVersion safeExtGet('BarcodeCreator_buildToolsVersion', '30.0.3')
+    compileSdkVersion safeExtGet('BarcodeCreator_compileSdkVersion', 34)
+    buildToolsVersion safeExtGet('BarcodeCreator_buildToolsVersion', '34.0.0')
     defaultConfig {
         minSdkVersion safeExtGet('BarcodeCreator_minSdkVersion', 23)
-        targetSdkVersion safeExtGet('BarcodeCreator_targetSdkVersion', 30)
+        targetSdkVersion safeExtGet('BarcodeCreator_targetSdkVersion', 34)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
I Updated the Android `build.gradle` to use SDK version 34 and build tools version 34.0.0 to solve build error in the following issue: https://github.com/VittoriDavide/react-native-barcode-creator/issues/10
<img width="946" alt="image" src="https://github.com/VittoriDavide/react-native-barcode-creator/assets/36933318/21882fa7-ad65-4563-9345-57afa11d82b2">

## Versions used
- `node version`: `v20.10.0`
- `java version`: `openjdk 11.0.21 2023-10-17 LTS`
