### PR TITLE
Fix build failure after Expo@52 upgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ def supportsNamespace() {
 
 android {
   if (supportsNamespace()) {
-    namespace "com.barcodecreator"
+    namespace "com.reactnativebarcodecreator"
 
     sourceSets {
       main {


### PR DESCRIPTION
Autolinking failed due to a namespace and folder name mismatch, causing build errors after upgrading Expo